### PR TITLE
Fix hero typewriter jitter and add expanded carousel navigation

### DIFF
--- a/src/components/ProjectCarousel.astro
+++ b/src/components/ProjectCarousel.astro
@@ -37,12 +37,25 @@ const { images, alt, autoRotateMs = 6000, icon } = Astro.props;
 
   <div class="carousel__lightbox" data-carousel-lightbox hidden>
     <button type="button" class="carousel__lightbox-backdrop" data-lightbox-backdrop aria-label="Close expanded view"></button>
+    {images.length > 1 && (
+      <button type="button" class="carousel__lightbox-nav carousel__lightbox-nav--prev" data-lightbox-prev aria-label="Previous screenshot">
+        <Icon name="lucide:chevron-left" aria-hidden="true" />
+      </button>
+    )}
     <div class="carousel__lightbox-panel" role="dialog" aria-modal="true" aria-label={`${alt} screenshot, expanded view`}>
       <button type="button" class="carousel__lightbox-close" data-lightbox-close aria-label="Close expanded view">
         <Icon name="lucide:x" aria-hidden="true" />
       </button>
       <img data-lightbox-img alt="" />
+      {images.length > 1 && (
+        <p class="carousel__lightbox-caption" data-lightbox-caption aria-live="polite"></p>
+      )}
     </div>
+    {images.length > 1 && (
+      <button type="button" class="carousel__lightbox-nav carousel__lightbox-nav--next" data-lightbox-next aria-label="Next screenshot">
+        <Icon name="lucide:chevron-right" aria-hidden="true" />
+      </button>
+    )}
   </div>
 
   <div class="carousel__controls">
@@ -221,6 +234,54 @@ const { images, alt, autoRotateMs = 6000, icon } = Astro.props;
     color: var(--color-accent-teal);
   }
 
+  /* Anchored to the lightbox overlay itself (not the panel) so the arrows
+     sit near the screen edges regardless of how wide the image/panel is. */
+  .carousel__lightbox-nav {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+
+  .carousel__lightbox-nav :global(svg) {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .carousel__lightbox-nav:hover,
+  .carousel__lightbox-nav:focus-visible {
+    border-color: var(--color-accent-teal);
+    color: var(--color-accent-teal);
+  }
+
+  .carousel__lightbox-nav--prev {
+    left: var(--space-4);
+  }
+
+  .carousel__lightbox-nav--next {
+    right: var(--space-4);
+  }
+
+  .carousel__lightbox-caption {
+    margin-top: var(--space-3);
+    text-align: center;
+    font-size: 0.8rem;
+    /* Fixed light tone rather than the theme token: the lightbox backdrop
+       is always a dark overlay regardless of light/dark mode, so the muted
+       text color (dark in light mode) would be unreadable against it. */
+    color: rgba(255, 255, 255, 0.85);
+  }
+
   .carousel__controls {
     display: flex;
     align-items: center;
@@ -298,6 +359,9 @@ const { images, alt, autoRotateMs = 6000, icon } = Astro.props;
     const lightboxImg = lightbox?.querySelector<HTMLImageElement>("[data-lightbox-img]");
     const lightboxClose = lightbox?.querySelector<HTMLButtonElement>("[data-lightbox-close]");
     const lightboxBackdrop = lightbox?.querySelector<HTMLButtonElement>("[data-lightbox-backdrop]");
+    const lightboxPrev = lightbox?.querySelector<HTMLButtonElement>("[data-lightbox-prev]");
+    const lightboxNext = lightbox?.querySelector<HTMLButtonElement>("[data-lightbox-next]");
+    const lightboxCaption = lightbox?.querySelector<HTMLElement>("[data-lightbox-caption]");
     let current = 0;
     let timerId: ReturnType<typeof setInterval> | undefined;
 
@@ -364,16 +428,56 @@ const { images, alt, autoRotateMs = 6000, icon } = Astro.props;
       timerId = undefined;
     }
 
+    // Keeps the lightbox's own image/caption in sync with `current` — used
+    // both when opening (to seed it) and whenever prev/next/swipe navigate
+    // while the lightbox is open, so the regular carousel index (dots,
+    // caption, and the slide it resumes on if closed) never drifts from
+    // what's shown expanded.
+    function syncLightbox() {
+      const activeSlide = slides[current];
+      if (!lightboxImg || !activeSlide) return;
+      lightboxImg.src = activeSlide.src;
+      lightboxImg.alt = activeSlide.alt;
+      if (lightboxCaption) lightboxCaption.textContent = `Preview ${current + 1} of ${slides.length}`;
+    }
+
+    function lightboxShow(direction: "next" | "previous") {
+      if (slides.length < 2) return;
+      show(direction === "next" ? current + 1 : current - 1, direction);
+      syncLightbox();
+    }
+
     function onLightboxKeydown(event: KeyboardEvent) {
       if (event.key === "Escape") closeLightbox();
+      else if (event.key === "ArrowLeft") lightboxShow("previous");
+      else if (event.key === "ArrowRight") lightboxShow("next");
+    }
+
+    let touchStartX = 0;
+    let touchStartY = 0;
+
+    function onLightboxTouchStart(event: TouchEvent) {
+      const touch = event.touches[0];
+      if (!touch) return;
+      touchStartX = touch.clientX;
+      touchStartY = touch.clientY;
+    }
+
+    function onLightboxTouchEnd(event: TouchEvent) {
+      const touch = event.changedTouches[0];
+      if (!touch) return;
+      const deltaX = touch.clientX - touchStartX;
+      const deltaY = touch.clientY - touchStartY;
+      const SWIPE_THRESHOLD = 40;
+      if (Math.abs(deltaX) > SWIPE_THRESHOLD && Math.abs(deltaX) > Math.abs(deltaY)) {
+        lightboxShow(deltaX < 0 ? "next" : "previous");
+      }
     }
 
     function openLightbox() {
-      const activeSlide = slides[current];
-      if (!lightbox || !lightboxImg || !activeSlide) return;
-      lightboxImg.src = activeSlide.src;
-      lightboxImg.alt = activeSlide.alt;
+      if (!lightbox || !lightboxImg) return;
       lightbox.hidden = false;
+      syncLightbox();
       stopAutoRotate();
       document.addEventListener("keydown", onLightboxKeydown);
       lightboxClose?.focus();
@@ -390,6 +494,10 @@ const { images, alt, autoRotateMs = 6000, icon } = Astro.props;
     expandBtn?.addEventListener("click", openLightbox);
     lightboxClose?.addEventListener("click", closeLightbox);
     lightboxBackdrop?.addEventListener("click", closeLightbox);
+    lightboxPrev?.addEventListener("click", () => lightboxShow("previous"));
+    lightboxNext?.addEventListener("click", () => lightboxShow("next"));
+    lightbox?.addEventListener("touchstart", onLightboxTouchStart, { passive: true });
+    lightbox?.addEventListener("touchend", onLightboxTouchEnd, { passive: true });
 
     prevBtn?.addEventListener("click", () => {
       show(current - 1, "previous");

--- a/src/components/TypewriterTicker.astro
+++ b/src/components/TypewriterTicker.astro
@@ -8,7 +8,16 @@ const { label, lines } = Astro.props;
 ---
 <div class="typewriter" data-lines={JSON.stringify(lines)}>
   <span class="typewriter__label">{label}</span>
-  <span class="typewriter__line"><span class="typewriter__text" aria-live="polite">{lines[0]}</span><span class="typewriter__cursor" aria-hidden="true">|</span></span>
+  <div class="typewriter__stage">
+    {lines.map((line) => (
+      // Trailing "|" mirrors the live cursor glyph appended after a fully
+      // typed line during its hold — without it, the sizer under-reserves
+      // by exactly the cursor's width and the real cursor can wrap onto an
+      // extra line the grid track never accounted for.
+      <span class="typewriter__sizer-line" aria-hidden="true">{line}|</span>
+    ))}
+    <span class="typewriter__line"><span class="typewriter__text" aria-live="polite">{lines[0]}</span><span class="typewriter__cursor" aria-hidden="true">|</span></span>
+  </div>
 </div>
 
 <style>
@@ -16,7 +25,7 @@ const { label, lines } = Astro.props;
      type and a hint of tinted surface, confined to this one element. */
   .typewriter {
     display: flex;
-    align-items: baseline;
+    align-items: flex-start;
     gap: var(--space-2);
     font-family: var(--font-mono);
     font-size: 0.9rem;
@@ -31,17 +40,36 @@ const { label, lines } = Astro.props;
     font-weight: 700;
     color: var(--color-text);
     white-space: nowrap;
+    /* Matches the stage's first line box so the label sits flush with the
+       top of the typed text instead of the whole (tallest-phrase) stage. */
+    line-height: 1.5em;
   }
 
-  /* min-width: 0 lets this flex item actually shrink below its text's
-     natural width so long lines wrap instead of overflowing the row.
-     Text and cursor are plain inline spans (not separate flex items)
-     inside here, so they flow and wrap together as one unit — the cursor
-     stays immediately after the last typed character even when the line
-     wraps, instead of parking at the far right of the flex row. */
-  .typewriter__line {
+  /* Grid-overlay sizer: every phrase (hidden) and the live typed line all
+     share grid-area 1/1, so the track height the grid reserves is the
+     tallest single phrase's wrapped height — not the sum of every phrase's
+     height, and not a hardcoded line-count guess. This is what stops the
+     bento cards below from bouncing as the ticker cycles through phrases
+     of different lengths. */
+  .typewriter__stage {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .typewriter__stage > * {
+    grid-area: 1 / 1;
     min-width: 0;
     overflow-wrap: anywhere;
+  }
+
+  /* Occupies layout (for height reservation) but never paints and is
+     pulled from the accessibility tree, so screen readers only ever hear
+     the single live `aria-live` line, not every phrase at once. */
+  .typewriter__sizer-line {
+    visibility: hidden;
   }
 
   .typewriter__cursor {


### PR DESCRIPTION
## Summary
- Hero `Currently:` typewriter no longer causes the bento dashboard to bounce as phrases of different lengths type/delete. Height is reserved via a hidden CSS grid-overlay sizer (all phrases + a trailing cursor-width character), not a hardcoded line count, so it adapts naturally across desktop/tablet/mobile.
- Expanded project screenshot lightbox now has previous/next navigation: visible arrow buttons, `ArrowLeft`/`ArrowRight` keyboard support, and touch swipe. The lightbox index stays in sync with the underlying carousel's dots/caption/current slide. Projects with only one screenshot render without nav controls.

## Test plan
- [x] `npm run build` and `npm run test` pass
- [x] Playwright: typewriter stage height + Experience/Projects card position sampled over multiple full phrase cycles on mobile (375px) and desktop (1440px) widths — zero variance
- [x] Playwright: lightbox next/prev buttons advance and sync main carousel dots/caption
- [x] Playwright: `ArrowLeft`/`ArrowRight` navigate and wrap correctly; `Escape` closes and returns focus to the expand button
- [x] Playwright: simulated touch swipe (left/right) navigates; small taps and vertical swipes don't trigger navigation
- [x] Verified in light and dark mode (lightbox caption/arrows readable against the dark backdrop in both themes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)